### PR TITLE
Add handler to upload multipart form data

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Powered by some great Go technology:
 - [zap](https://github.com/uber-go/zap) - for logging
 
 ## Things that have been said in Helm land
->"Finally!!" 
+>"Finally!!"
 
 >"ChartMuseum is awesome"
 
@@ -69,6 +69,12 @@ curl --data-binary "@mychart-0.1.0.tgz" http://localhost:8080/api/charts
 If you've signed your package and generated a [provenance file](https://github.com/kubernetes/helm/blob/master/docs/provenance.md), upload it with:
 ```bash
 curl --data-binary "@mychart-0.1.0.tgz.prov" http://localhost:8080/api/prov
+```
+
+Both files can also be uploaded at once (or one at a time) on the `api/charts` route using the `multipart/form-data` format:
+
+```bash
+curl -F "chart=@mychart-0.1.0.tgz" -F "prov=@mychart-0.1.0.tgz.prov" http://localhost:8080/api/charts
 ```
 
 ## Installing Charts into Kubernetes

--- a/cmd/chartmuseum/main.go
+++ b/cmd/chartmuseum/main.go
@@ -40,15 +40,17 @@ func cliHandler(c *cli.Context) {
 	backend := backendFromContext(c)
 
 	options := chartmuseum.ServerOptions{
-		Debug:          c.Bool("debug"),
-		LogJSON:        c.Bool("log-json"),
-		EnableAPI:      !c.Bool("disable-api"),
-		ChartURL:       c.String("chart-url"),
-		TlsCert:        c.String("tls-cert"),
-		TlsKey:         c.String("tls-key"),
-		Username:       c.String("basic-auth-user"),
-		Password:       c.String("basic-auth-pass"),
-		StorageBackend: backend,
+		Debug:                  c.Bool("debug"),
+		LogJSON:                c.Bool("log-json"),
+		EnableAPI:              !c.Bool("disable-api"),
+		ChartURL:               c.String("chart-url"),
+		TlsCert:                c.String("tls-cert"),
+		TlsKey:                 c.String("tls-key"),
+		Username:               c.String("basic-auth-user"),
+		Password:               c.String("basic-auth-pass"),
+		StorageBackend:         backend,
+		ChartPostFormFieldName: c.String("chart-post-form-field-name"),
+		ProvPostFormFieldName:  c.String("prov-post-form-field-name"),
 	}
 
 	server, err := newServer(options)
@@ -206,5 +208,17 @@ var cliFlags = []cli.Flag{
 		Name:   "storage-google-prefix",
 		Usage:  "prefix to store charts for --storage-google-bucket",
 		EnvVar: "STORAGE_GOOGLE_PREFIX",
+	},
+	cli.StringFlag{
+		Name:   "chart-post-form-field-name",
+		Value:  "chart",
+		Usage:  "name of the POST form field which will be queried for the chart file content",
+		EnvVar: "CHART_POST_FORM_FIELD_NAME",
+	},
+	cli.StringFlag{
+		Name:   "prov-post-form-field-name",
+		Value:  "prov",
+		Usage:  "name of the POST form field which will be queried for the provenance file content",
+		EnvVar: "PROV_POST_FORM_FIELD_NAME",
 	},
 }

--- a/pkg/chartmuseum/routes.go
+++ b/pkg/chartmuseum/routes.go
@@ -8,7 +8,7 @@ func (server *Server) setRoutes(enableAPI bool) {
 	// Chart Manipulation
 	if enableAPI {
 		server.Router.GET("/api/charts", server.getAllChartsRequestHandler)
-		server.Router.POST("/api/charts", server.postPackageRequestHandler)
+		server.Router.POST("/api/charts", server.postRequestHandler)
 		server.Router.POST("/api/prov", server.postProvenanceFileRequestHandler)
 		server.Router.GET("/api/charts/:name", server.getChartRequestHandler)
 		server.Router.GET("/api/charts/:name/:version", server.getChartVersionRequestHandler)

--- a/pkg/chartmuseum/server.go
+++ b/pkg/chartmuseum/server.go
@@ -27,27 +27,31 @@ type (
 
 	// Server contains a Logger, Router, storage backend and object cache
 	Server struct {
-		Logger           *Logger
-		Router           *Router
-		RepositoryIndex  *repo.Index
-		StorageBackend   storage.Backend
-		StorageCache     []storage.Object
-		StorageCacheLock *sync.Mutex
-		TlsCert          string
-		TlsKey           string
+		Logger                 *Logger
+		Router                 *Router
+		RepositoryIndex        *repo.Index
+		StorageBackend         storage.Backend
+		StorageCache           []storage.Object
+		StorageCacheLock       *sync.Mutex
+		TlsCert                string
+		TlsKey                 string
+		ChartPostFormFieldName string
+		ProvPostFormFieldName  string
 	}
 
 	// ServerOptions are options for constructing a Server
 	ServerOptions struct {
-		StorageBackend storage.Backend
-		LogJSON        bool
-		Debug          bool
-		EnableAPI      bool
-		ChartURL       string
-		TlsCert        string
-		TlsKey         string
-		Username       string
-		Password       string
+		StorageBackend         storage.Backend
+		LogJSON                bool
+		Debug                  bool
+		EnableAPI              bool
+		ChartURL               string
+		TlsCert                string
+		TlsKey                 string
+		Username               string
+		Password               string
+		ChartPostFormFieldName string
+		ProvPostFormFieldName  string
 	}
 )
 
@@ -95,14 +99,16 @@ func NewServer(options ServerOptions) (*Server, error) {
 	router := NewRouter(logger, options.Username, options.Password)
 
 	server := &Server{
-		Logger:           logger,
-		Router:           router,
-		RepositoryIndex:  repo.NewIndex(options.ChartURL),
-		StorageBackend:   options.StorageBackend,
-		StorageCache:     []storage.Object{},
-		StorageCacheLock: &sync.Mutex{},
-		TlsCert:          options.TlsCert,
-		TlsKey:           options.TlsKey,
+		Logger:                 logger,
+		Router:                 router,
+		RepositoryIndex:        repo.NewIndex(options.ChartURL),
+		StorageBackend:         options.StorageBackend,
+		StorageCache:           []storage.Object{},
+		StorageCacheLock:       &sync.Mutex{},
+		TlsCert:                options.TlsCert,
+		TlsKey:                 options.TlsKey,
+		ChartPostFormFieldName: options.ChartPostFormFieldName,
+		ProvPostFormFieldName:  options.ProvPostFormFieldName,
 	}
 
 	server.setRoutes(options.EnableAPI)


### PR DESCRIPTION
This PR implements what has been proposed and discussed in https://github.com/chartmuseum/chartmuseum/issues/7, namely, a new handler allowing `multipart/form-data` uploads on the `api/charts` route:

```bash
curl -F "chart=@mychart-0.1.0.tgz" http://localhost:8080/api/charts
curl -F "prov=@mychart-0.1.0.tgz.prov" http://localhost:8080/api/charts
curl -F "chart=@mychart-0.1.0.tgz" -F "prov=@mychart-0.1.0.tgz.prov" http://localhost:8080/api/charts
```

The added complexity is mainly due to the fact that the new route should be able to handle both chart and provenance files (at once, or separately), and provide atomicity: if a chart and a provenance file are provided for instance, the chart should not be stored if the provenance file is somehow faulty, and vice versa: both should succeed or fail, together. Also note that although it is not strictly necessary (because the filenames can be obtained from the form data), I have reused the functions `repo.ChartPackageFilenameFromContent` and `repo.ProvenanceFilenameFromContent` as a validation mechanism. 

I'd like to thank my colleague @davidovich for the help and support!